### PR TITLE
Support calling decode_get_pdr_resp with a NULL buffer

### DIFF
--- a/libpldm/platform.c
+++ b/libpldm/platform.c
@@ -216,7 +216,7 @@ int decode_get_pdr_resp(const struct pldm_msg *msg, size_t payload_length,
 {
 	if (msg == NULL || completion_code == NULL ||
 	    next_record_hndl == NULL || next_data_transfer_hndl == NULL ||
-	    transfer_flag == NULL || resp_cnt == NULL || record_data == NULL ||
+	    transfer_flag == NULL || resp_cnt == NULL ||
 	    transfer_crc == NULL) {
 		return PLDM_ERROR_INVALID_DATA;
 	}
@@ -249,7 +249,7 @@ int decode_get_pdr_resp(const struct pldm_msg *msg, size_t payload_length,
 		return PLDM_ERROR_INVALID_LENGTH;
 	}
 
-	if (*resp_cnt > 0) {
+	if (*resp_cnt > 0 && record_data != NULL) {
 		if (record_data_length < *resp_cnt) {
 			return PLDM_ERROR_INVALID_LENGTH;
 		}

--- a/libpldm/platform.h
+++ b/libpldm/platform.h
@@ -682,7 +682,8 @@ int encode_get_pdr_req(uint8_t instance_id, uint32_t record_hndl,
  *        transferred
  *  @param[out] resp_cnt - The number of recordData bytes returned in this
  *        response
- *  @param[out] record_data - PDR data bytes of length resp_cnt
+ *  @param[out] record_data - PDR data bytes of length resp_cnt, or NULL to
+ *        skip the copy and place the actual length in resp_cnt.
  *  @param[in] record_data_length - Length of record_data
  *  @param[out] transfer_crc - A CRC-8 for the overall PDR. This is present only
  *        in the last part of a PDR being transferred


### PR DESCRIPTION
This commit adds support to decode_get_pdr_resp to allow callers to
supply a NULL buffer pointer to retrieve the actual length of the PDR
data.