### PR TITLE
Update libpldm api encode_*_req functions to have payload_length param

### DIFF
--- a/libpldm/fru.c
+++ b/libpldm/fru.c
@@ -4,22 +4,28 @@
 #include "fru.h"
 
 int encode_get_fru_record_table_metadata_req(uint8_t instance_id,
-					     struct pldm_msg *msg)
+               struct pldm_msg *msg,
+               size_t payload_length)
 {
-	if (msg == NULL) {
-		return PLDM_ERROR_INVALID_DATA;
-	}
+  if (msg == NULL) {
+    return PLDM_ERROR_INVALID_DATA;
+  }
 
-	struct pldm_header_info header = {0};
-	header.instance = instance_id;
-	header.msg_type = PLDM_REQUEST;
-	header.pldm_type = PLDM_FRU;
-	header.command = PLDM_GET_FRU_RECORD_TABLE_METADATA;
-	int rc = pack_pldm_header(&header, &(msg->hdr));
-	if (PLDM_SUCCESS != rc) {
-		return rc;
-	}
-	return PLDM_SUCCESS;
+  if (payload_length != PLDM_GET_FRU_RECORD_TABLE_METADATA_REQ_BYTES) {
+    return PLDM_ERROR_INVALID_LENGTH;
+  }
+
+  struct pldm_header_info header = {0};
+  header.instance = instance_id;
+  header.msg_type = PLDM_REQUEST;
+  header.pldm_type = PLDM_FRU;
+  header.command = PLDM_GET_FRU_RECORD_TABLE_METADATA;
+  int rc = pack_pldm_header(&header, &(msg->hdr));
+  if (PLDM_SUCCESS != rc) {
+    return rc;
+  }
+
+  return PLDM_SUCCESS;
 }
 
 int decode_get_fru_record_table_metadata_resp(

--- a/libpldm/fru.h
+++ b/libpldm/fru.h
@@ -11,9 +11,12 @@ extern "C" {
 
 #include "base.h"
 
+#define PLDM_GET_FRU_RECORD_TABLE_METADATA_REQ_BYTES 0
 #define PLDM_GET_FRU_RECORD_TABLE_METADATA_RESP_BYTES 19
 #define PLDM_GET_FRU_RECORD_TABLE_REQ_BYTES 5
 #define PLDM_GET_FRU_RECORD_TABLE_MIN_RESP_BYTES 6
+
+#define FRU_TABLE_CHECKSUM_SIZE 4
 
 /** @brief PLDM FRU commands
  */
@@ -131,12 +134,14 @@ struct pldm_fru_record_data_format {
  *
  *  @param[in] instance_id - Message's instance id
  *  @param[in,out] msg - Message will be written to this
+ *  @param[in] payload_length - Length of the request message payload
  *  @return pldm_completion_codes
  *  @note  Caller is responsible for memory alloc and dealloc of param
  *         'msg.payload'
  */
 int encode_get_fru_record_table_metadata_req(uint8_t instance_id,
-					     struct pldm_msg *msg);
+               struct pldm_msg *msg,
+               size_t payload_length);
 
 /** @brief Decode GetFruRecordTable response data
  *

--- a/libpldm/platform.c
+++ b/libpldm/platform.c
@@ -625,7 +625,8 @@ int encode_platform_event_message_req(uint8_t instance_id,
 				      uint8_t event_class,
 				      const uint8_t *event_data,
 				      size_t event_data_length,
-				      struct pldm_msg *msg)
+				      struct pldm_msg *msg,
+              size_t payload_length)
 
 {
 	struct pldm_header_info header = {0};
@@ -647,6 +648,11 @@ int encode_platform_event_message_req(uint8_t instance_id,
 	if (event_data_length == 0) {
 		return PLDM_ERROR_INVALID_DATA;
 	}
+
+  if (payload_length !=
+        PLDM_PLATFORM_EVENT_MESSAGE_MIN_REQ_BYTES + event_data_length) {
+    return PLDM_ERROR_INVALID_LENGTH;
+}
 
 	if (event_class > PLDM_HEARTBEAT_TIMER_ELAPSED_EVENT &&
 	    !(event_class >= 0xF0 && event_class <= 0xFE)) {

--- a/libpldm/platform.h
+++ b/libpldm/platform.h
@@ -977,7 +977,8 @@ int encode_platform_event_message_req(uint8_t instance_id,
 				      uint8_t event_class,
 				      const uint8_t *event_data,
 				      size_t event_data_length,
-				      struct pldm_msg *msg);
+				      struct pldm_msg *msg,
+              size_t payload_length);
 
 /** @brief Decode PlatformEventMessage response data
  * @param[in] msg - Request message

--- a/libpldm/tests/libpldm_fru_test.cpp
+++ b/libpldm/tests/libpldm_fru_test.cpp
@@ -11,7 +11,10 @@ TEST(GetFruRecordTableMetadata, testGoodEncodeRequest)
 {
     std::array<uint8_t, sizeof(pldm_msg_hdr)> requestMsg{};
     auto requestPtr = reinterpret_cast<pldm_msg*>(requestMsg.data());
-    auto rc = encode_get_fru_record_table_metadata_req(0, requestPtr);
+    auto rc = encode_get_fru_record_table_metadata_req(
+                                0,
+                                requestPtr,
+                                PLDM_GET_FRU_RECORD_TABLE_METADATA_REQ_BYTES);
     ASSERT_EQ(rc, PLDM_SUCCESS);
     ASSERT_EQ(requestPtr->hdr.request, PLDM_REQUEST);
     ASSERT_EQ(requestPtr->hdr.instance_id, 0);
@@ -21,8 +24,12 @@ TEST(GetFruRecordTableMetadata, testGoodEncodeRequest)
 
 TEST(GetFruRecordTableMetadata, testBadEncodeRequest)
 {
-    auto rc = encode_get_fru_record_table_metadata_req(0, NULL);
+    auto rc = encode_get_fru_record_table_metadata_req(0, NULL, 0);
     ASSERT_EQ(rc, PLDM_ERROR_INVALID_DATA);
+    std::array<uint8_t, sizeof(pldm_msg_hdr)> requestMsg{};
+    auto requestPtr = reinterpret_cast<pldm_msg*>(requestMsg.data());
+    auto rc = encode_get_fru_record_table_metadata_req(0, requestPtr , 1);
+    ASSERT_EQ(rc, PLDM_ERROR_INVALID_LENGTH);
 }
 
 TEST(GetFruRecordTableMetadata, testGoodDecodeResponse)

--- a/libpldm/tests/libpldm_platform_test.cpp
+++ b/libpldm/tests/libpldm_platform_test.cpp
@@ -870,7 +870,8 @@ TEST(PlatformEventMessage, testGoodEncodeRequest)
     auto request = reinterpret_cast<pldm_msg*>(requestMsg.data());
     auto rc = encode_platform_event_message_req(
         0, formatVersion, Tid, eventClass,
-        reinterpret_cast<uint8_t*>(&eventData), sizeof(eventData), request);
+        reinterpret_cast<uint8_t*>(&eventData), sizeof(eventData), request,
+        sizeof(eventData) + PLDM_PLATFORM_EVENT_MESSAGE_MIN_REQ_BYTES);
 
     struct pldm_platform_event_message_req* req =
         reinterpret_cast<struct pldm_platform_event_message_req*>(
@@ -888,6 +889,8 @@ TEST(PlatformEventMessage, testBadEncodeRequest)
     uint8_t Tid = 0x03;
     uint8_t eventClass = 0x00;
     uint8_t eventData = 34;
+    size_t  sz_eventData = sizeof(eventData);
+    size_t  payloadLen = sz_eventData + PLDM_PLATFORM_EVENT_MESSAGE_MIN_REQ_BYTES;
     uint8_t formatVersion = 0x01;
 
     std::array<uint8_t, hdrSize + PLDM_PLATFORM_EVENT_MESSAGE_MIN_REQ_BYTES +
@@ -896,16 +899,21 @@ TEST(PlatformEventMessage, testBadEncodeRequest)
     auto request = reinterpret_cast<pldm_msg*>(requestMsg.data());
     auto rc = encode_platform_event_message_req(
         0, formatVersion, Tid, eventClass,
-        reinterpret_cast<uint8_t*>(&eventData), sizeof(eventData), nullptr);
+        reinterpret_cast<uint8_t*>(&eventData), sizeof(eventData), nullptr,
+        payloadLen);
 
     EXPECT_EQ(rc, PLDM_ERROR_INVALID_DATA);
     rc = encode_platform_event_message_req(
         0, 0, Tid, eventClass, reinterpret_cast<uint8_t*>(&eventData),
-        sizeof(eventData), request);
+        sizeof(eventData), request, payloadLen);
     EXPECT_EQ(rc, PLDM_ERROR_INVALID_DATA);
     rc = encode_platform_event_message_req(0, formatVersion, Tid, eventClass,
-                                           nullptr, 0, request);
+                                           nullptr, 0, request,payloadLen);
     EXPECT_EQ(rc, PLDM_ERROR_INVALID_DATA);
+    rc = encode_platform_event_message_req(0, format_version, Tid, eventClass,
+                                           reinterpret_cast<uint8_t*>(&eventData),
+                                           sizeof(event_data), request, 0)
+    EXPECT_EQ(rc, PLDM_ERROR_INVALID_LENGTH);
 }
 
 TEST(PlatformEventMessage, testGoodDecodeResponse)

--- a/tool/pldm_fru_cmd.cpp
+++ b/tool/pldm_fru_cmd.cpp
@@ -35,7 +35,10 @@ class GetFruRecordTableMetadata : public CommandInterface
         std::vector<uint8_t> requestMsg(sizeof(pldm_msg_hdr));
         auto request = reinterpret_cast<pldm_msg*>(requestMsg.data());
 
-        auto rc = encode_get_fru_record_table_metadata_req(instanceId, request);
+        auto rc = encode_get_fru_record_table_metadata_req(
+                                  instanceId,
+                                  request,
+                                  PLDM_GET_FRU_RECORD_TABLE_METADATA_REQ_BYTES);
         return {rc, requestMsg};
     }
 


### PR DESCRIPTION
There were a few of the APIs in libpldm's fru and platform that Hostboot was using downstream that
did not have the payload_length param which the Hostboot templates expect. All encode_*_req functions should end with a payload_length parameter and this commit moves us towards that goal.